### PR TITLE
feat: (헤더) 사용자 이름 옆에 로그아웃 아이콘 버튼 추가 및 (RefreshOverlay) fadeout 딜레이 조정

### DIFF
--- a/src/app/customer/components/Header/DesktopHeader.tsx
+++ b/src/app/customer/components/Header/DesktopHeader.tsx
@@ -4,10 +4,10 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Icon from "@mdi/react";
-import { mdiMagnify, mdiAccountCircle } from "@mdi/js";
+import {mdiMagnify, mdiAccountCircle, mdiLogout} from "@mdi/js";
 import { AppBar, Toolbar, IconButton } from "@mui/material";
 import "./Header.scss";
-import { useSession } from "next-auth/react";
+import {signOut, useSession} from "next-auth/react";
 
 export default function DesktopHeader() {
     const pathname = usePathname();
@@ -26,11 +26,14 @@ export default function DesktopHeader() {
                         <IconButton disableTouchRipple component={Link} href="/customer/auth/signin" className={`DesktopHeader_icon ${pathname === "/customer/auth/signin" ? "active" : ""}`}><Icon path={mdiAccountCircle} size={1} /></IconButton>
                         {/*로그인시, oo님*/}
                         {status === "authenticated" && session?.user?.name && (
-                            <span style={{ color: "#FFFFFF", fontSize: "1.0rem" }}>
+                            <span style={{ color: "#FFFFFF", fontSize: "0.9rem" }}>
                                 {session.user.name}님
                             </span>
                         )}
-                    </div>
+                        {status === "authenticated" && (
+                            <IconButton disableTouchRipple onClick={() => signOut({callbackUrl: "/customer"})} className= "DesktopHeader_icon" title= "로그아웃"><Icon path={mdiLogout} size={1} /></IconButton>
+                        )}
+                        </div>
                 </Toolbar>
             </div>
         </AppBar>

--- a/src/app/customer/components/Header/MobileHeader.tsx
+++ b/src/app/customer/components/Header/MobileHeader.tsx
@@ -5,10 +5,10 @@ import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Icon from "@mdi/react";
-import { mdiMagnify, mdiAccountCircle, mdiMenu, mdiChevronRight } from "@mdi/js";
+import {mdiMagnify, mdiAccountCircle, mdiMenu, mdiChevronRight, mdiLogout} from "@mdi/js";
 import { AppBar, Toolbar, IconButton, Drawer, List, InputBase, ListItemButton } from "@mui/material";
 import "./Header.scss";
-import { useSession } from "next-auth/react";
+import {signOut, useSession} from "next-auth/react";
 
 export default function MobileHeader() {
     const pathname = usePathname();
@@ -31,6 +31,9 @@ export default function MobileHeader() {
                             <span style={{ color: "#FFFFFF", fontSize: "0.7rem" }}>
                                 {session.user.name}님
                             </span>
+                        )}
+                        {status === "authenticated" && (
+                            <IconButton disableTouchRipple onClick={() => signOut({callbackUrl: "/customer"})} className= "DesktopHeader_icon" title= "로그아웃"><Icon path={mdiLogout} size={1} /></IconButton>
                         )}
                         <IconButton onClick={() => toggleDrawer(!isDrawerOpen)} className={`MobileHeader_icon ${isDrawerOpen ? "active" : ""}`}>
                             <Icon path={mdiMenu} size={1} />

--- a/src/app/customer/components/RefreshOverlay/RefreshOverlay.tsx
+++ b/src/app/customer/components/RefreshOverlay/RefreshOverlay.tsx
@@ -29,7 +29,7 @@ export default function RefreshOverlay({ children }: { children: React.ReactNode
 
         const timeout = setTimeout(()=> {
             setFadeOut(true);
-        }, 200);
+        }, 700);
 
         return () => {
             clearInterval(interval);


### PR DESCRIPTION
아이콘 클릭 시 signOut() + 콜백 경로 적용,
아이콘 버튼에 title 속성 추가로 접근성 향상,
fadeout 트랜지션 딜레이 700ms으로 조정