### PR TITLE
feat: 전화번호 인증 테이블 생성 및 회원가입 로직/페이지 변경

### DIFF
--- a/prisma/migrations/20250512163726_add_phone_verification/migration.sql
+++ b/prisma/migrations/20250512163726_add_phone_verification/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[phone]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE `User` ADD COLUMN `phone` VARCHAR(191) NULL;
+
+-- CreateTable
+CREATE TABLE `PhoneVerification` (
+    `phone` VARCHAR(191) NOT NULL,
+    `code` VARCHAR(191) NOT NULL,
+    `expiresAt` DATETIME(3) NOT NULL,
+    `verified` BOOLEAN NOT NULL DEFAULT false,
+
+    PRIMARY KEY (`phone`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `User_phone_key` ON `User`(`phone`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,10 +14,18 @@ model User {
   emailVerified DateTime?
   image         String?
   password      String?  // 자체 로그인용 비밀번호
+  phone         String?   @unique
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
   accounts      Account[]
   sessions      Session[]
+}
+
+model PhoneVerification {
+  phone     String   @id
+  code      String
+  expiresAt DateTime
+  verified  Boolean  @default(false)
 }
 
 model Account {

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -5,13 +5,20 @@ import bcrypt from "bcryptjs";
 const prisma = new PrismaClient();
 
 export async function POST(request: Request) {
-    const { name, email, password } = await request.json();
+    const { name, email, password, phone } = await request.json();
 
-    if (!email || !password) {
+    if (!email || !password || !phone) {
         return NextResponse.json({ error: "입력 항목이 누락되었습니다" }, { status: 400 });
     }
 
-    const existingUser = await prisma.user.findUnique({ where: { email } });
+    const existingUser = await prisma.user.findFirst({
+        where: {
+           OR: [
+               {email},
+               {phone}
+           ]
+        }
+    });
 
     if (existingUser) {
         return NextResponse.json({ error: "이미 등록된 사용자입니다" }, { status: 400 });
@@ -24,6 +31,7 @@ export async function POST(request: Request) {
             name,
             email,
             password: hashedPassword,
+            phone,
         },
     });
 

--- a/src/app/customer/auth/register/page.tsx
+++ b/src/app/customer/auth/register/page.tsx
@@ -8,6 +8,7 @@ export default function RegisterPage() {
     const [email, setEmail] = useState("");
     const [name, setName] = useState("");
     const [password, setPassword] = useState("");
+    const [phone, setPhone] = useState("");
     const router = useRouter();
 
     const handleRegister = async (e: React.FormEvent) => {
@@ -54,7 +55,7 @@ export default function RegisterPage() {
         // 검증 통과한 경우에만 회원가입 요청
         const res = await fetch("/api/register", {
             method: "POST",
-            body: JSON.stringify({ email, name, password }),
+            body: JSON.stringify({ email, name, password, phone }),
             headers: { "Content-Type": "application/json" },
         });
 
@@ -99,6 +100,13 @@ export default function RegisterPage() {
                         value={email}
                         onChange={e => setEmail(e.target.value)}
                         placeholder="이메일"
+                        required
+                    />
+                    <input
+                        type="text"
+                        value={phone}
+                        onChange={e => setPhone(e.target.value)}
+                        placeholder="전화번호(숫자만 입력해주세요)"
                         required
                     />
                     <input


### PR DESCRIPTION
기존 user 테이블에 phone 컬럼 추가,
phoneVerification 테이블 생성,
백엔드 회원가입 API에서 전화번호 처리 로직 추가,
회원가입 페이지에 전화번호 입력 필드 추가,
중복 체크 시 email 또는 phone 둘 중 하나라도 존재하면 가입 제한되도록 수정